### PR TITLE
Add information about application secrets

### DIFF
--- a/node-app/README.md
+++ b/node-app/README.md
@@ -6,13 +6,13 @@ Example Node application
 
 This app uses [Google's "functions framework" node package](https://github.com/GoogleCloudPlatform/functions-framework-nodejs). This provides an Express-based framework for writing HTTP handlers that can be run locally or in Google Cloud.
 
-### Setup
+## Setup
 
 ```shell
 $ npm install
 ```
 
-### Running locally
+## Running locally
 
 ```shell
 $ npm run start
@@ -20,7 +20,7 @@ $ npm run start
 
 Your service will be running at [http://localhost:8080](http://localhost:8080).
 
-### Deploying to Google Cloud
+## Deploying to Google Cloud
 
 > [!IMPORTANT]
 > Please change the application's name in the APP_NAME file. The name must be unique.
@@ -42,3 +42,49 @@ After this finishes:
 - your application image will be in [Google's Artifact Registry](https://console.cloud.google.com/artifacts/docker/hackday-2025-support/europe/eu.gcr.io?project=hackday-2025-support)
 - you should see your service in the [Cloud Run console](https://console.cloud.google.com/run?project=hackday-2025-support)
 - you can explore the service's logs and settings from its entry in the Cloud Run console, above
+
+## Secrets
+
+The CAPI API KEY for this hackday has been made available to the application as a secret in Google Cloud. You can read it from your application's environment as `CAPI_API_KEY`.
+
+When running the application locally, you can add `CAPI_API_KEY` to the environment so it matches production, either by exporting it from your shell or adding it to the start command.
+
+```shell
+$ export CAPI_API_KEY="???"
+$ npm run start
+```
+
+```shell
+$ CAPI_API_KEY="???" npm run start
+```
+
+### Adding your own secret
+
+To add other secrets to your application, follow these steps:
+
+1. Create a new secret in Secrets Manager.
+2. Add it to your application's environment by editing your deploy script.
+3. Re-deploy your application by running the deploy script.
+
+Step by step, we create a secret in Google's Secret Manager and then populate the secret with the correct value.
+
+```shell
+$ gcloud secrets create MY_APP_SECRET --replication-policy="automatic"
+$ echo -n "???" | gcloud secrets versions add MY_APP_SECRET --data-file=-
+```
+
+Then we add an environment variable called `MY_APP_SECRET` to your application's deploy script. The environment variable is populated from the latest value of a secret called `MY_APP_SECRET` in Google's Secret Manager (which we created above).
+
+```diff
+   --allow-unauthenticated \
++  --update-secrets "MY_APP_SECRET=MY_APP_SECRET:latest" \
+   --update-secrets "CAPI_API_KEY=CAPI_API_KEY:latest"
+```
+
+Finally, we re-deploy the application by running the deploy script.
+
+```shell
+$ npm run deploy
+```
+
+**Please ensure your secrets are uniquely named**, since we're all using a shared hack day project.

--- a/node-app/README.md
+++ b/node-app/README.md
@@ -45,7 +45,7 @@ After this finishes:
 
 ## Secrets
 
-The CAPI API KEY for this hackday has been made available to the application as a secret in Google Cloud. You can read it from your application's environment as `CAPI_API_KEY`.
+The Content API KEY for this hackday has been made available to the application as a secret in Google Cloud. You can read it from your application's environment as `CAPI_API_KEY`.
 
 When running the application locally, you can add `CAPI_API_KEY` to the environment so it matches production, either by exporting it from your shell or adding it to the start command.
 

--- a/node-app/README.md
+++ b/node-app/README.md
@@ -76,9 +76,9 @@ $ echo -n "???" | gcloud secrets versions add MY_APP_SECRET --data-file=-
 Then we add an environment variable called `MY_APP_SECRET` to your application's deploy script. The environment variable is populated from the latest value of a secret called `MY_APP_SECRET` in Google's Secret Manager (which we created above).
 
 ```diff
-   --allow-unauthenticated \
-+  --update-secrets "MY_APP_SECRET=MY_APP_SECRET:latest" \
-   --update-secrets "CAPI_API_KEY=CAPI_API_KEY:latest"
+  --allow-unauthenticated \
++ --update-secrets "MY_APP_SECRET=MY_APP_SECRET:latest" \
+  --update-secrets "CAPI_API_KEY=CAPI_API_KEY:latest"
 ```
 
 Finally, we re-deploy the application by running the deploy script.

--- a/node-app/scripts/deploy.sh
+++ b/node-app/scripts/deploy.sh
@@ -44,29 +44,22 @@ if [[ "$APPLICATION_NAME" == "node-hello-world" ]]; then
   error_exit "APPLICATION_NAME is still set to the template default 'node-hello-world'. Please change it to your app's name."
 fi
 
-# --- Configuration ---
+# --- Configuration --
 REGION="europe-west2" # London
 REPOSITORY_PREFIX="eu.gcr.io"
+SHARED_SERVICE_ACCOUNT_EMAIL="guardian-hackday-shared-sa@${PROJECT_ID}.iam.gserviceaccount.com"
 
 # --- Setup variables ---
 IMAGE_NAME="${APPLICATION_NAME}-image"
 SERVICE_NAME="${APPLICATION_NAME}-service"
-SERVICE_ACCOUNT_NAME="${APPLICATION_NAME}-sa"
-SERVICE_ACCOUNT_EMAIL="${SERVICE_ACCOUNT_NAME}@${PROJECT_ID}.iam.gserviceaccount.com"
 
 # --- Ensure script is run from project root ---
 if [[ ! -f "Dockerfile" ]]; then
   error_exit "Script must be run from the project root directory (Dockerfile missing)."
 fi
 
-# --- Ensure service account exists ---
-info "Checking service account $SERVICE_ACCOUNT_EMAIL..."
-if ! gcloud iam service-accounts describe "$SERVICE_ACCOUNT_EMAIL" >/dev/null 2>&1; then
-  warning "Service account not found. Creating $SERVICE_ACCOUNT_NAME..."
-  gcloud iam service-accounts create "$SERVICE_ACCOUNT_NAME" \
-    --display-name "Service Account for $SERVICE_NAME"
-  sleep 3 # IAM resource creation can take a few seconds to propagate
-fi
+# --- Shared service account ---
+info "Using shared service account: $SHARED_SERVICE_ACCOUNT_EMAIL"
 
 # --- Build and push the container image ---
 info "Building container image..."
@@ -81,8 +74,9 @@ gcloud run deploy "$SERVICE_NAME" \
   --image "$REPOSITORY_PREFIX/$PROJECT_ID/$IMAGE_NAME" \
   --platform managed \
   --region "$REGION" \
-  --service-account "$SERVICE_ACCOUNT_EMAIL" \
-  --allow-unauthenticated
+  --service-account "$SHARED_SERVICE_ACCOUNT_EMAIL" \
+  --allow-unauthenticated \
+  --update-secrets "CAPI_API_KEY=CAPI_API_KEY:latest"
 
 # --- Output service URL ---
 success "Deployment complete!"

--- a/node-app/src/index.js
+++ b/node-app/src/index.js
@@ -2,6 +2,7 @@ const functions = require('@google-cloud/functions-framework');
 const express = require('express');
 const fs = require('fs');
 const path = require('path');
+const escape = require('escape-html');
 
 // Read application name from APP_NAME file
 // this keeps it in sync with the deploy script
@@ -16,7 +17,8 @@ app.get('/', (req, res) => {
 });
 
 app.get('/hello/world', (req, res) => {
-  const name = req.query.name || 'World';
+  const rawName = req.query.name || 'World';
+  const name = escape(rawName);
   res.send(`Hello, ${name}!`);
 });
 

--- a/scala-app/README.md
+++ b/scala-app/README.md
@@ -7,7 +7,7 @@ Example Scala application
 > [!WARNING]
 > This project requires Java 21. If you are using [mise](https://mise.jdx.dev/) to manage dev tools this will be handled for you, otherwise please ensure Java 21 is installed and active.
 
-### Running locally
+## Running locally
 
 You can run `sbt run` to start the app, but for a better developer experience you can use the following workflow.
 
@@ -22,7 +22,7 @@ $ sbt
 
 Your service will be running at [http://localhost:8080](http://localhost:8080).
 
-### Deploying to Google Cloud
+## Deploying to Google Cloud
 
 > [!IMPORTANT]
 > Please change the application name in the [APP_NAME](APP_NAME) file. The name must be unique.
@@ -46,10 +46,58 @@ After this finishes:
 - your service should be publicly available on the internet (the URL will have been printed to the console)
 - you can explore the service's logs and settings from its entry in the Cloud Run console, above
 
-### Choice of webserver library
+## Choice of webserver library
 
 We typically use the [Play framework](https://www.playframework.com/) for Scala applications, but this is complex to set up for a hackday and is not a great fit for Cloud Run's architecture. Instead, this demo app uses [Tapir](https://tapir.softwaremill.com/en/latest/) to create a simple webserver definition. We avoid the use of `Future` by choosing a webserver that takes advantage of Java 21's virtual threads.
 
 [The Scala demo app](./src/main/scala/example/Hello.scala) is a little more full-featured than the Node one, to demonstrate how to achieve a few common patterns using Tapir.
 
 Using Tapir this way also gives us the ability to automatically generate [API documentation](https://swagger.io/tools/swagger-ui/) for the application, which you will see at `/docs` on your running service.
+
+## Secrets
+
+The CAPI API KEY for this hackday has been made available to the application as a secret in Google Cloud. You can read it from your application's environment as `CAPI_API_KEY`.
+
+When running the application locally, you can add `CAPI_API_KEY` to the environment so it matches production, either by exporting it from your shell or adding it to the start command.
+
+```shell
+$ export CAPI_API_KEY="???"
+$ sbt
+...
+```
+
+```shell
+$ CAPI_API_KEY="???" sbt
+...
+```
+
+### Adding your own secret
+
+To add other secrets to your application, follow these steps:
+
+1. Create a new secret in Secrets Manager.
+2. Add it to your application's environment by editing your deploy script.
+3. Re-deploy your application by running the deploy script.
+
+Step by step, we create a secret in Google's Secret Manager and then populate the secret with the correct value.
+
+```shell
+$ gcloud secrets create MY_APP_SECRET --replication-policy="automatic"
+$ echo -n "???" | gcloud secrets versions add MY_APP_SECRET --data-file=-
+```
+
+Then we add an environment variable called `MY_APP_SECRET` to your application's deploy script. The environment variable is populated from the latest value of a secret called `MY_APP_SECRET` in Google's Secret Manager (which we created above).
+
+```diff
+   --allow-unauthenticated \
++  --update-secrets "MY_APP_SECRET=MY_APP_SECRET:latest" \
+   --update-secrets "CAPI_API_KEY=CAPI_API_KEY:latest"
+```
+
+Finally, we re-deploy the application by running the deploy script.
+
+```shell
+$ ./scripts/deploy.sh
+```
+
+**Please ensure your secrets are uniquely named**, since we're all using a shared hack day project.

--- a/scala-app/README.md
+++ b/scala-app/README.md
@@ -56,7 +56,7 @@ Using Tapir this way also gives us the ability to automatically generate [API do
 
 ## Secrets
 
-The CAPI API KEY for this hackday has been made available to the application as a secret in Google Cloud. You can read it from your application's environment as `CAPI_API_KEY`.
+The Content API KEY for this hackday has been made available to the application as a secret in Google Cloud. You can read it from your application's environment as `CAPI_API_KEY`.
 
 When running the application locally, you can add `CAPI_API_KEY` to the environment so it matches production, either by exporting it from your shell or adding it to the start command.
 

--- a/scala-app/README.md
+++ b/scala-app/README.md
@@ -89,9 +89,9 @@ $ echo -n "???" | gcloud secrets versions add MY_APP_SECRET --data-file=-
 Then we add an environment variable called `MY_APP_SECRET` to your application's deploy script. The environment variable is populated from the latest value of a secret called `MY_APP_SECRET` in Google's Secret Manager (which we created above).
 
 ```diff
-   --allow-unauthenticated \
-+  --update-secrets "MY_APP_SECRET=MY_APP_SECRET:latest" \
-   --update-secrets "CAPI_API_KEY=CAPI_API_KEY:latest"
+  --allow-unauthenticated \
++ --update-secrets "MY_APP_SECRET=MY_APP_SECRET:latest" \
+  --update-secrets "CAPI_API_KEY=CAPI_API_KEY:latest"
 ```
 
 Finally, we re-deploy the application by running the deploy script.

--- a/scala-app/build.sbt
+++ b/scala-app/build.sbt
@@ -24,6 +24,7 @@ lazy val root = (project in file("."))
       "com.softwaremill.sttp.client4" %% "core" % sttpVersion,
       "com.softwaremill.sttp.client4" %% "circe" % sttpVersion,
       // tooling
+      "org.apache.commons" % "commons-text" % "1.13.1",
       "ch.qos.logback" % "logback-classic" % "1.5.18",
       "org.scalatest" %% "scalatest" % "3.2.19" % Test
     ),

--- a/scala-app/src/main/scala/example/Hello.scala
+++ b/scala-app/src/main/scala/example/Hello.scala
@@ -8,6 +8,7 @@ import sttp.tapir.generic.auto.*
 import sttp.tapir.json.circe.*
 import sttp.tapir.server.netty.sync.NettySyncServer
 import sttp.tapir.swagger.bundle.SwaggerInterpreter
+import org.apache.commons.text.StringEscapeUtils.escapeHtml4
 
 @main def main(): Unit = {
   NettySyncServer()
@@ -42,9 +43,12 @@ object Routes {
   private val hello = endpoint.get
     .in("hello" / "world")
     .in(query[Option[String]]("name"))
-    .out(stringBody)
+    .out(htmlBodyUtf8)
     .handleSuccess { maybeName =>
-      s"Hello, ${maybeName.getOrElse("world")}!"
+      val name = maybeName
+        .map(escapeHtml4)
+        .getOrElse("world")
+      s"Hello, $name!"
     }
 
   /** Endpoint that returns User objects as JSON
@@ -70,7 +74,6 @@ object Routes {
   private val ipInformation = endpoint.get
     .in("ip-info")
     .out(jsonBody[Ip])
-    .errorOut(stringBody)
     .handleSuccess { _ =>
       val ipData = basicRequest
         .get(uri"https://api.myip.com/")


### PR DESCRIPTION


We add the CAPI_API_KEY as an example secret, since this is one that will be commonly used. Also documents the process for adding a new secret.

For simplicity, we switch to using a shared service account that is pre-granted access to all the secrets in Secret Manager.

Also demonstrate best practices by escaping the value obtained from the `name` GET variable before displaying it.

